### PR TITLE
Skip unknown-language packages in search fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **HexDocs search broken for Elixir/Erlang packages** — modern ExDoc (≥ v0.34) no longer generates `search_data.json` or `search-data.json`. Instead it generates `dist/search_data-{DIGEST}.js` containing a JS variable assignment (`searchData={...}`). hexplorer now falls back to fetching `search.html`, scraping the `<script src="dist/search_data-*.js">` tag, fetching the JS file, and parsing its `searchData=` payload. Packages built with older ExDoc (flat JSON) continue to work as before.
-
+- **Cross-language package leaking into filtered views** — when searching by a specific language (e.g. Gleam) and the full-text search returned no results, the exact-name fallback lookup would accept packages with unknown build tools (`Language::All`) and re-label them as the selected language. For example, `credo` (Elixir) appeared as a Gleam package. The fallback now only includes packages whose `build_tools` positively confirm the selected language; packages from a different ecosystem are silently skipped and the search returns empty.
 - **Docs search error surfaced in UI** — when all fetch strategies fail, a red error message is shown in the docs-search view instead of silently displaying an empty list.
 
 ## [0.1.4] — 2026-04-04

--- a/src/api.rs
+++ b/src/api.rs
@@ -402,13 +402,20 @@ pub async fn fetch_packages(
 
         // Fallback: if even the 500-package search returns nothing, try an exact name lookup.
         // Handles packages outside the top-500 (e.g. very new or niche packages).
+        // NOTE: only include the package if we can positively confirm it belongs to the
+        // selected language. Packages with unknown build_tools (Language::All) are excluded
+        // to avoid showing e.g. Elixir packages labelled as Gleam.
         if packages.is_empty() {
             info!("[fetch] search fallback: no results from full-text search, trying exact package lookup for {q}");
-            if let Ok(mut pkg) = fetch_package(q).await {
-                if pkg.language == language || pkg.language == Language::All {
+            if let Ok(pkg) = fetch_package(q).await {
+                if pkg.language == language {
                     info!("[fetch] fallback exact package found: {q} lang={language}");
-                    pkg.language = language;
                     packages.push(pkg);
+                } else {
+                    info!(
+                        "[fetch] fallback exact package {q} has language={}, expected {language} — skipping",
+                        pkg.language
+                    );
                 }
             }
         }


### PR DESCRIPTION
When the full-text search returned no results, the exact-name fallback previously accepted packages with unknown build tools and re-labeled them as the selected language. This change updates the fallback to only include packages whose language positively matches the requested language, removes the reassignment of pkg.language.