### PR TITLE
#19 filtering doc search results 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.1.6] — 2026-04-07
 
+### Added
+
+- **Live filter in HexDocs search view** — after results load, type any characters to narrow the list in real time. The header search bar shows the active filter. `Backspace` / `Ctrl+W` work as usual. Exiting the view (`Esc`/`q`) restores the previous list search keyword.
+
 ### Fixed
 
-- **HexDocs search regression for Gleam packages** — `parse_search_data` searched for `=` in the entire body, finding it inside string values (URLs, Gleam `key=value` patterns) and slicing the JSON at the wrong position. Pure JSON bodies are now parsed directly; `=` is only scanned after the `searchData` keyword for JS assignment format.
-- **Docs search cascade now covers `.js` variants** — direct candidates extended with `search_data.js`, `search-data.js`, `dist/search_data.js`, `dist/search-data.js`; same variants added to HTML asset discovery. Each step continues on empty results instead of returning early.
-- **Unit tests** added for `parse_search_data` and `find_search_index_url` covering the regression case and all format variants.
+- **HexDocs search regression for Gleam packages** — `parse_search_data` used `find('=')` on the entire body, hitting `=` inside string values (URLs, `key=value` patterns) and slicing the JSON incorrectly. Pure JSON is now parsed directly; `=` is only scanned after the `searchData` keyword.
+- **Docs search cascade extended** — direct candidates now include `search_data.js`, `search-data.js`, `dist/search_data.js`, `dist/search-data.js` for packages that serve the index as a JS file. HTML asset discovery updated with the same variants.
 
 ## [0.1.5] — 2026-04-05
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -120,7 +120,10 @@ pub struct App {
     pub docs_search_input: String,
     /// True while the search_data.json fetch is in flight.
     pub docs_search_loading: bool,
-    /// Results from the last HexDocs search, filtered locally.
+    /// Full result set from the last HexDocs fetch (filtered by the initial query term).
+    /// The `input` field is used as a live secondary filter on top of this.
+    docs_search_all_results: Vec<SearchItem>,
+    /// Visible subset of `docs_search_all_results` after applying the `input` filter.
     pub docs_search_results: Vec<SearchItem>,
     /// Cursor index into `docs_search_results`.
     pub docs_search_cursor: usize,
@@ -130,6 +133,8 @@ pub struct App {
     pub docs_search_error: Option<String>,
     /// View to return to when closing DocsSearch (List or Detail).
     prev_view: View,
+    /// `input` value saved when entering DocsSearch — restored on exit.
+    prev_input: String,
     /// Active docs cache TTL in hours — mirrors settings_config, loaded at startup.
     pub docs_cache_ttl_hours: u32,
     tx: Sender<Msg>,
@@ -178,11 +183,13 @@ impl App {
             docs_search_mode: false,
             docs_search_input: String::new(),
             docs_search_loading: false,
+            docs_search_all_results: vec![],
             docs_search_results: vec![],
             docs_search_cursor: 0,
             docs_search_pkg: String::new(),
             docs_search_error: None,
             prev_view: View::List,
+            prev_input: String::new(),
             docs_cache_ttl_hours: storage::load_meta()
                 .map(|m| m.config.docs_cache_ttl_hours)
                 .unwrap_or(24),
@@ -343,8 +350,8 @@ impl App {
                 );
                 self.docs_search_loading = false;
                 self.docs_search_error = None;
-                self.docs_search_results = results;
-                self.docs_search_cursor = 0;
+                self.docs_search_all_results = results;
+                self.apply_docs_filter();
             }
             Msg::DocsSearchError(_term, error) => {
                 error!("[msg] DocsSearchError: {error}");
@@ -712,7 +719,10 @@ impl App {
         };
         self.docs_search_pkg = pkg_name.clone();
         self.prev_view = self.view;
+        self.prev_input = self.input.clone();
+        self.input = String::new();
         self.view = View::DocsSearch;
+        self.docs_search_all_results.clear();
         self.docs_search_results.clear();
         self.docs_search_cursor = 0;
         self.docs_search_error = None;
@@ -721,7 +731,7 @@ impl App {
         let ttl = self.docs_cache_ttl_hours;
         if let Some(cached_items) = cache::get_docs(&pkg_name, ttl) {
             let q = term.to_lowercase();
-            self.docs_search_results = cached_items
+            self.docs_search_all_results = cached_items
                 .into_iter()
                 .filter(|item| {
                     item.title.to_lowercase().contains(&q)
@@ -729,6 +739,7 @@ impl App {
                 })
                 .take(50)
                 .collect();
+            self.docs_search_results = self.docs_search_all_results.clone();
             self.docs_search_loading = false;
             return;
         }
@@ -761,7 +772,9 @@ impl App {
         match key.code {
             KeyCode::Char('q') | KeyCode::Esc => {
                 self.view = self.prev_view;
+                self.docs_search_all_results.clear();
                 self.docs_search_results.clear();
+                self.input = self.prev_input.clone();
             }
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return true,
             KeyCode::Down | KeyCode::Char('j') => {
@@ -782,9 +795,45 @@ impl App {
                     let _ = open::that(url);
                 }
             }
+            // Live filter: typing narrows the result list.
+            KeyCode::Backspace if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                delete_word_back(&mut self.input);
+                self.apply_docs_filter();
+            }
+            KeyCode::Char('w') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                delete_word_back(&mut self.input);
+                self.apply_docs_filter();
+            }
+            KeyCode::Backspace => {
+                self.input.pop();
+                self.apply_docs_filter();
+            }
+            KeyCode::Char(c) => {
+                self.input.push(c);
+                self.apply_docs_filter();
+            }
             _ => {}
         }
         false
+    }
+
+    /// Re-filter `docs_search_all_results` through the current `input` value
+    /// and update `docs_search_results`. Resets the cursor to 0.
+    fn apply_docs_filter(&mut self) {
+        let q = self.input.trim().to_lowercase();
+        self.docs_search_results = if q.is_empty() {
+            self.docs_search_all_results.clone()
+        } else {
+            self.docs_search_all_results
+                .iter()
+                .filter(|item| {
+                    item.title.to_lowercase().contains(&q)
+                        || item.parent_title.to_lowercase().contains(&q)
+                })
+                .cloned()
+                .collect()
+        };
+        self.docs_search_cursor = 0;
     }
 
     fn key_docs_search(&mut self, key: KeyEvent) -> bool {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -95,27 +95,43 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
     draw_tab_bar(f, app, center);
 
     // ── Right: search + sort ──────────────────────────────────────────────────
-    let (search_txt, search_sty) = if app.input_mode {
+    let (search_txt, search_sty, search_border) = if app.view == View::DocsSearch {
+        if app.input.is_empty() {
+            (
+                "  type to filter results…".to_string(),
+                Style::new().fg(p.dim).italic(),
+                Style::new().fg(accent),
+            )
+        } else {
+            (
+                format!("  /{}_", app.input),
+                Style::new().fg(p.yellow).bold(),
+                Style::new().fg(p.yellow),
+            )
+        }
+    } else if app.input_mode {
         (
             format!("  /{}_", app.input),
             Style::new().fg(p.yellow).bold(),
+            Style::new().fg(p.yellow),
         )
     } else if app.input.is_empty() {
         (
             "  press / to search…".to_string(),
             Style::new().fg(p.dim).italic(),
+            Style::new().fg(accent),
         )
     } else {
-        (format!("  /{}", app.input), Style::new().fg(p.white))
+        (
+            format!("  /{}", app.input),
+            Style::new().fg(p.white),
+            Style::new().fg(accent),
+        )
     };
 
     let search_block = Block::bordered()
         .border_type(BorderType::Rounded)
-        .border_style(if app.input_mode {
-            Style::new().fg(p.yellow)
-        } else {
-            Style::new().fg(accent)
-        });
+        .border_style(search_border);
 
     let lines = vec![
         Line::from(Span::styled(search_txt, search_sty)),
@@ -1062,7 +1078,9 @@ fn draw_footer(f: &mut Frame, app: &App, area: Rect) {
             Span::styled("↑↓ j k", Style::new().fg(accent).bold()),
             Span::styled(" navigate  ", Style::new().fg(p.dim)),
             Span::styled("enter", Style::new().fg(accent).bold()),
-            Span::styled(" open in browser", Style::new().fg(p.dim)),
+            Span::styled(" open  ", Style::new().fg(p.dim)),
+            Span::styled("type", Style::new().fg(p.yellow).bold()),
+            Span::styled(" filter results", Style::new().fg(p.dim)),
         ],
         View::Settings => vec![
             Span::styled(" esc / q", Style::new().fg(SETTINGS_ACCENT).bold()),


### PR DESCRIPTION
This PR introduces a live filtering feature for the HexDocs search view, allowing users to narrow down search results in real time as they type. It also improves the user interface to reflect the active filter and clarifies the changelog. Several internal changes were made to support live filtering, including state management and UI updates.

**Feature: Live Filter for HexDocs Search**
- Added a live filter to the HexDocs search view: after results load, users can type to filter the list in real time; the header search bar displays the active filter, and exiting the view restores the previous search keyword. 


ISSUE #19 