### PR TITLE
Use per-package HexDocs subdomains and bump to 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to hexplorer are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.8] - 2026-06-14
+
+### Changed
+
+- HexDocs URLs now use per-package subdomains (`PKG.hexdocs.pm`) instead of the shared path form (`hexdocs.pm/PKG`). Package names with underscores map to hyphens in the subdomain, so `gleam_stdlib` resolves to `gleam-stdlib.hexdocs.pm`. A new `docs_base_url` helper builds the canonical URL and is used by the search-index fetch and both doc-link openers. Old path URLs still redirect, so this just skips the redirect hop. See <https://hex.pm/blog/hexdocs-per-package-subdomains> (closes #23).
+
 ## [0.1.7] — 2026-04-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hexplorer"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexplorer"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["lupodevelop <you@example.com>"]
 description = "Terminal UI for browsing HEX.pm package registry for the BEAM ecosystem"

--- a/src/api.rs
+++ b/src/api.rs
@@ -74,7 +74,7 @@ pub struct Package {
 
 // ── HexDocs search types (re-exported from docs module) ──────────────────────
 
-pub use crate::docs::{fetch_docs_search_data, SearchItem};
+pub use crate::docs::{docs_base_url, fetch_docs_search_data, SearchItem};
 
 // ── GitHub types ──────────────────────────────────────────────────────────────
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -828,8 +828,7 @@ impl App {
             }
             KeyCode::Enter => {
                 if let Some(item) = self.docs_search_results.get(self.docs_search_cursor) {
-                    let url =
-                        format!("{}{}", docs_base_url(&self.docs_search_pkg), item.ref_url);
+                    let url = format!("{}{}", docs_base_url(&self.docs_search_pkg), item.ref_url);
                     let _ = open::that(url);
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 
 use crate::{
     api::{
-        fetch_by_names, fetch_docs_search_data, fetch_github_stats, fetch_package, fetch_packages,
-        github_token, GhResult, Package, SearchItem,
+        docs_base_url, fetch_by_names, fetch_docs_search_data, fetch_github_stats, fetch_package,
+        fetch_packages, github_token, GhResult, Package, SearchItem,
     },
     cache::{self, CacheMap, CachedEntry},
     favorites,
@@ -828,10 +828,8 @@ impl App {
             }
             KeyCode::Enter => {
                 if let Some(item) = self.docs_search_results.get(self.docs_search_cursor) {
-                    let url = format!(
-                        "https://hexdocs.pm/{}/{}",
-                        self.docs_search_pkg, item.ref_url
-                    );
+                    let url =
+                        format!("{}{}", docs_base_url(&self.docs_search_pkg), item.ref_url);
                     let _ = open::that(url);
                 }
             }

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -148,9 +148,27 @@ fn decode_entity(entity: &str) -> Option<String> {
 /// **Step 2 — HTML discovery** (if all direct candidates fail):
 ///   Fetch `search.html`, scan `<script src="...">` for known asset paths,
 ///   fetch the discovered asset, or parse inline `searchData = {...}` from the page.
+/// Build the canonical HexDocs base URL for a package.
+///
+/// As of 2026-06-01 HexDocs serves each package from its own subdomain
+/// (`PKG.hexdocs.pm`) instead of a shared path (`hexdocs.pm/PKG`) to isolate
+/// packages under the browser same-origin policy. Underscores in package names
+/// are not valid in DNS labels, so they map to hyphens
+/// (`ecto_sql` → `ecto-sql.hexdocs.pm`). Old path URLs still redirect, but we
+/// emit the canonical form to avoid the redirect hop.
+///
+/// See <https://hex.pm/blog/hexdocs-per-package-subdomains>.
+///
+/// The returned string always ends with a trailing slash, so a relative
+/// `ref_url` can be appended directly.
+pub fn docs_base_url(package: &str) -> String {
+    let slug = package.replace('_', "-");
+    format!("https://{slug}.hexdocs.pm/")
+}
+
 pub async fn fetch_docs_search_data(package: &str) -> Result<Vec<SearchItem>> {
     let c = client()?;
-    let base = format!("https://hexdocs.pm/{package}/");
+    let base = docs_base_url(package);
     info!("[docs] fetch_docs_search_data package={package}");
 
     // ── Step 1: direct URL candidates ────────────────────────────────────────
@@ -455,6 +473,19 @@ mod tests {
     }
 
     // ── find_search_index_url ─────────────────────────────────────────────────
+
+    #[test]
+    fn docs_base_url_plain_package() {
+        assert_eq!(docs_base_url("lustre"), "https://lustre.hexdocs.pm/");
+    }
+
+    #[test]
+    fn docs_base_url_underscores_become_hyphens() {
+        assert_eq!(
+            docs_base_url("gleam_stdlib"),
+            "https://gleam-stdlib.hexdocs.pm/"
+        );
+    }
 
     #[test]
     fn find_url_from_script_src_json() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,6 +6,7 @@ use ratatui::{
 };
 
 use crate::{
+    api::docs_base_url,
     app::{App, GhState},
     fmt,
     types::{Language, LinkStyle, Palette, SettingRow, View},
@@ -988,7 +989,7 @@ fn draw_docs_search_view(f: &mut Frame, app: &App, area: Rect) {
                 }
                 acc
             });
-        let url = format!("https://hexdocs.pm/{pkg}/{}", item.ref_url);
+        let url = format!("{}{}", docs_base_url(pkg), item.ref_url);
         let lines = vec![
             Line::from(Span::styled(
                 "─".repeat(snippet_area.width as usize),


### PR DESCRIPTION
HexDocs moved each package to its own subdomain (PKG.hexdocs.pm) to isolate packages under the same-origin policy. Underscores in package names map to hyphens in the subdomain.

Add a docs_base_url helper and route the search-index fetch and both doc-link openers through it. Old path URLs still redirect, so this is non-breaking and just avoids the redirect hop.

Closes #23